### PR TITLE
Add keyboardAppearance prop to TextInput child

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ const styles = StyleSheet.create({
 | onCodeChanged | NO | Callback when the digits are changed |
 | onCodeFilled | NO | Callback when the last digit is entered |
 | secureTextEntry | NO | Hide contents of text fields |
+| keyboardAppearance | NO | Keyboard appearance ('default', 'dark', 'light') |
 | keyboardType | NO | Keyboard type |
 | clearInputs | NO | Clear inputs after entering code |
 | placeholderCharacter | NO | The character/string that will be used as placeholder in the individual code input fields |

--- a/index.tsx
+++ b/index.tsx
@@ -11,6 +11,7 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
         pinCount: 6,
         autoFocusOnLoad: true,
         secureTextEntry: false,
+        keyboardAppearance: "default",
         keyboardType: "number-pad",
         clearInputs: false,
         placeholderCharacter: "",
@@ -179,7 +180,7 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
     }
 
     renderOneInputField = (_: TextInput, index: number) => {
-        const { codeInputFieldStyle, codeInputHighlightStyle, secureTextEntry, keyboardType, selectionColor } = this.props
+        const { codeInputFieldStyle, codeInputHighlightStyle, secureTextEntry, keyboardType, selectionColor, keyboardAppearance } = this.props
         const { defaultTextFieldStyle } = styles
         const { selectedIndex, digits } = this.state
         const { clearInputs, placeholderCharacter, placeholderTextColor } = this.props
@@ -196,6 +197,7 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
                     }}
                     onKeyPress={({ nativeEvent: { key } }) => { this.handleKeyPressTextInput(index, key) }}
                     value={ !clearInputs ? digits[index]: "" }
+                    keyboardAppearance={keyboardAppearance}
                     keyboardType={keyboardType}
                     textContentType={isAutoFillSupported ? "oneTimeCode" : "none"}
                     key={index}


### PR DESCRIPTION
Allows for using a dark appearance in situations where that is preferred.