### PR TITLE
Fix Bug always hightlight first slot even autoFocusOnLoad=false

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -28,7 +28,7 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
         const { code } = props
         this.state = {
             digits: codeToArray(code),
-            selectedIndex: 0,
+            selectedIndex: props.autoFocusOnLoad ? 0 : -1,
         }
     }
 


### PR DESCRIPTION
I set autoFocusOnLoad = false but the first slot always highlighted. This PR could fix the problem.
Thank You