### PR TITLE
Adding clipboard from community packages and removing from react-native

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,7 +1,8 @@
 /// <reference path="index.d.ts" />
 import { InputProps, OTPInputViewState } from '@twotalltotems/react-native-otp-input';
 import React, { Component } from 'react'
-import { View, TextInput, TouchableWithoutFeedback, Clipboard, Keyboard, Platform, I18nManager, EmitterSubscription, } from 'react-native'
+import { View, TextInput, TouchableWithoutFeedback, Keyboard, Platform, I18nManager, EmitterSubscription, } from 'react-native'
+import Clipboard from '@react-native-community/clipboard';
 import styles from './styles'
 import { isAutoFillSupported } from './helpers/device'
 import { codeToArray } from './helpers/codeToArray'

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/jest": "^25.1.4",
     "@types/react": "^16.9.25",
     "@types/react-native": "^0.61.23",
+    "@react-native-community/clipboard": "^1.2.2",
     "babel-jest": "^25.1.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",


### PR DESCRIPTION
Clipboard import from react-native returns warning messages and is currently deprecated, it should instead should be imported from @react-native-community package as @react-native-community/clipboard