### PR TITLE
migrates Clipboard from react-native core to @react-native-community/clipboard

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,7 +1,8 @@
 /// <reference path="index.d.ts" />
 import { InputProps, OTPInputViewState } from '@twotalltotems/react-native-otp-input';
 import React, { Component } from 'react'
-import { View, TextInput, TouchableWithoutFeedback, Clipboard, Keyboard, Platform, I18nManager, EmitterSubscription, } from 'react-native'
+import { View, TextInput, TouchableWithoutFeedback, Keyboard, Platform, I18nManager, EmitterSubscription, } from 'react-native'
+import Clipboard from '@react-native-community/clipboard';
 import styles from './styles'
 import { isAutoFillSupported } from './helpers/device'
 import { codeToArray } from './helpers/codeToArray'

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "react-dom": "^16.12.0",
     "react-native": "^0.61.5",
     "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "@react-native-community/clipboard": "^1.2.2"
   }
 }


### PR DESCRIPTION
migrates `Clipboard` from `react-native` core to `@react-native-community/clipboard`

See: [migrating-from-the-core-react-native-module](https://github.com/react-native-community/clipboard#migrating-from-the-core-react-native-module)