### PR TITLE
Add a max length of 1 for each individual input

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -208,6 +208,7 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
                     editable={editable}
                     placeholder={placeholderCharacter}
                     placeholderTextColor={placeholderTextColor || defaultPlaceholderTextColor}
+                    maxLength={1}
                 />
             </View>
         )


### PR DESCRIPTION
Issue
A single input (typically the last input) can contain several digits in some situations.

Reproduction
- the component is used in controlled mode (passing `code` and `onCodeChanged`)
- the user enters the code manually, and relatively fast.

When the user enters the code and the callback execution is slightly delayed, a single input can contain several digits.
This causes flickering and potentially inconsistent behaviour.

This is the most efficient fix to guarantee that each input cannot contain more than 1 digit at any given time. I could not see any issue with this, but let me know if otherwise.

In any case, thanks a lot for this library, it's really useful!
