### PR TITLE
feat: Add input groups

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ declare module '@twotalltotems/react-native-otp-input' {
   type KeyboardType = 'default' | 'email-address' | 'number-pad' | 'phone-pad';
 
   export interface InputProps {
+    pinGroups: number;
     /**
      * Digits of pins in the OTP
      */

--- a/index.tsx
+++ b/index.tsx
@@ -18,6 +18,7 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
         clearInputs: false,
         placeholderCharacter: "",
         selectionColor: '#000',
+        pinGroups: 1,
     }
 
     private fields: TextInput[] | null[] = []
@@ -213,10 +214,24 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
         )
     }
 
+    renderTextGroups = (pinList: TextInput[],groupIndex: number, pinPerGroups: number)=>{
+        const currentIndex= (groupIndex*pinPerGroups)
+
+        return ( 
+        <View pointerEvents="none" key={groupIndex + "view"} testID="inputGroupSlotView" style={{marginHorizontal:15}}>
+            {pinList.slice(currentIndex,(currentIndex+pinPerGroups)).map((pinVal,pinIndex) =>{
+            this.renderOneInputField(pinVal,(currentIndex+pinIndex))
+        })}
+        </View>)
+    }
     renderTextFields = () => {
-        const { pinCount } = this.props
-        const array = new Array(pinCount).fill(0)
-        return array.map(this.renderOneInputField)
+        const { pinCount, pinGroups } = this.props
+        const pinPerGrops = Math.ceil(pinCount/pinGroups);            
+        const pinCountArray = new Array(pinCount).fill(0)
+        const pinGroupsArray = new Array(pinGroups).fill(0)
+        return pinGroupsArray.map((_,index)=>{
+            return this.renderTextGroups(pinCountArray,index,pinPerGrops)
+        })
     }
 
     render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,11 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-native-community/clipboard@^1.2.2":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/clipboard/-/clipboard-1.5.1.tgz#32abb3ea2eb91ee3f9c5fb1d32d5783253c9fabe"
+  integrity sha512-AHAmrkLEH5UtPaDiRqoULERHh3oNv7Dgs0bTC0hO5Z2GdNokAMPT5w8ci8aMcRemcwbtdHjxChgtjbeA38GBdA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"


### PR DESCRIPTION
This Pull request is to add a input group, as some projects have a specific design to display groups of OTP,
This commit alows this type of implementation:
![image](https://github.com/tttstudios/react-native-otp-input/assets/51704551/d017e84d-39d0-498d-ab4d-6c0a699e3819)

To add input groups ther is a new Props called "pinGroups" which will split the layout into groups