### PR TITLE
🐛 fixed null SMS string

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2,7 +2,7 @@
 import { InputProps, OTPInputViewState } from '@twotalltotems/react-native-otp-input';
 import React, { Component } from 'react'
 import { View, TextInput, TouchableWithoutFeedback, Keyboard, Platform, I18nManager, EmitterSubscription, } from 'react-native'
-import Clipboard from '@react-native-community/clipboard';
+import * as Clipboard from 'expo-clipboard';
 import styles from './styles'
 import { isAutoFillSupported } from './helpers/device'
 import { codeToArray } from './helpers/codeToArray'
@@ -91,23 +91,38 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
     }
 
     checkPinCodeFromClipBoard = () => {
-        const { pinCount, onCodeFilled } = this.props
-        const regexp = new RegExp(`^\\d{${pinCount}}$`)
-        Clipboard.getString().then(code => {
-            if (this.hasCheckedClipBoard && regexp.test(code) && (this.clipBoardCode !== code)) {
-                this.setState({
-                    digits: code.split(""),
-                }, () => {
-                    this.blurAllFields()
-                    this.notifyCodeChanged()
-                    onCodeFilled && onCodeFilled(code)
-                })
-            }
-            this.clipBoardCode = code
-            this.hasCheckedClipBoard = true
-        }).catch(() => {
-        })
-    }
+        const { pinCount, onCodeFilled } = this.props;
+        const regexp = new RegExp(`^\\d{${pinCount}}$`);
+    
+        Clipboard.getStringAsync()
+            .then(code => {
+                if (!code) {
+                    console.log('Clipboard is empty or not accessible');
+                    return;
+                }
+    
+                if (this.hasCheckedClipBoard && regexp.test(code) && (this.clipBoardCode !== code)) {
+                    this.setState(
+                        {
+                            digits: code.split(""),
+                        },
+                        () => {
+                            this.blurAllFields();
+                            this.notifyCodeChanged();
+                            if (onCodeFilled) {
+                                onCodeFilled(code);
+                            }
+                        }
+                    );
+                }
+    
+                this.clipBoardCode = code;
+                this.hasCheckedClipBoard = true;
+            })
+            .catch(error => {
+                console.error('Error accessing clipboard:', error);
+            });
+    };
 
     private handleChangeText = (index: number, text: string) => {
         const { onCodeFilled, pinCount } = this.props


### PR DESCRIPTION
Migrated to using expo clipboard to resolve null getString from clipboard. 

Issue was found if phone did not have a SIM card and therefore did not receive a SMS, the clipboard would return null and break. This fixes as it allows null, so the user can type the code if there is none, or auto paste if they receive.