### PR TITLE
Use custom fork of @twotalltotems/react-native-otp-input after Removed clipboard usage

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -2,7 +2,7 @@
 import { InputProps, OTPInputViewState } from '@twotalltotems/react-native-otp-input';
 import React, { Component } from 'react'
 import { View, TextInput, TouchableWithoutFeedback, Keyboard, Platform, I18nManager, EmitterSubscription, } from 'react-native'
-import Clipboard from '@react-native-community/clipboard';
+//import Clipboard from '@react-native-community/clipboard';
 import styles from './styles'
 import { isAutoFillSupported } from './helpers/device'
 import { codeToArray } from './helpers/codeToArray'
@@ -93,20 +93,20 @@ export default class OTPInputView extends Component<InputProps, OTPInputViewStat
     checkPinCodeFromClipBoard = () => {
         const { pinCount, onCodeFilled } = this.props
         const regexp = new RegExp(`^\\d{${pinCount}}$`)
-        Clipboard.getString().then(code => {
-            if (this.hasCheckedClipBoard && regexp.test(code) && (this.clipBoardCode !== code)) {
-                this.setState({
-                    digits: code.split(""),
-                }, () => {
-                    this.blurAllFields()
-                    this.notifyCodeChanged()
-                    onCodeFilled && onCodeFilled(code)
-                })
-            }
-            this.clipBoardCode = code
-            this.hasCheckedClipBoard = true
-        }).catch(() => {
-        })
+        // Clipboard.getString().then(code => {
+        //     if (this.hasCheckedClipBoard && regexp.test(code) && (this.clipBoardCode !== code)) {
+        //         this.setState({
+        //             digits: code.split(""),
+        //         }, () => {
+        //             this.blurAllFields()
+        //             this.notifyCodeChanged()
+        //             onCodeFilled && onCodeFilled(code)
+        //         })
+        //     }
+        //     this.clipBoardCode = code
+        //     this.hasCheckedClipBoard = true
+        // }).catch(() => {
+        // })
     }
 
     private handleChangeText = (index: number, text: string) => {


### PR DESCRIPTION
- Removed @twotalltotems/react-native-otp-input from NPM registry
- Removed deprecated @react-native-community/clipboard
- Added GitHub-based forked version under caterstation org
